### PR TITLE
add statuscode to debug info

### DIFF
--- a/lib/kubernetes-deploy/kubectl.rb
+++ b/lib/kubernetes-deploy/kubectl.rb
@@ -52,7 +52,7 @@ module KubernetesDeploy
           @logger.warn("#{warning}: #{Shellwords.join(cmd)}")
           @logger.warn(err) unless output_is_sensitive
         else
-          @logger.debug("Kubectl err: #{output_is_sensitive ? '<suppressed sensitive output>' : err}")
+          @logger.debug("Kubectl err: #{output_is_sensitive ? '<suppressed sensitive output>' : err}, status: #{st}")
         end
         StatsD.increment('kubectl.error', 1, tags: { context: @context, namespace: @namespace, cmd: cmd[1] })
 

--- a/lib/kubernetes-deploy/version.rb
+++ b/lib/kubernetes-deploy/version.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 module KubernetesDeploy
-  VERSION = "1.5.5"
+  VERSION = "1.5.6"
 end


### PR DESCRIPTION
Current output doesn't help much: 

```[DEBUG][2020-01-21 17:48:00 +0000]	Running command (attempt 1): kubectl create -f /tmp/ConfigMap-proxysql20200121-88-13ag1rw.yml --dry-run --output=name --namespace=dev-inventory --context=aws-dev --request-timeout=15

[DEBUG][2020-01-21 17:48:00 +0000]	Running command (attempt 1): kubectl create -f /tmp/ConfigMap-inventory20200121-88-2704u6.yml --dry-run --output=name --namespace=dev-inventory --context=aws-dev --request-timeout=15

[DEBUG][2020-01-21 17:48:00 +0000]	Running command (attempt 1): kubectl create -f /tmp/Endpoints-influxdb20200121-88-152noqq.yml --dry-run --output=name --namespace=dev-inventory --context=aws-dev --request-timeout=15

[DEBUG][2020-01-21 17:48:00 +0000]	Running command (attempt 1): kubectl create -f /tmp/Service-inventory20200121-88-1lsdyke.yml --dry-run --output=name --namespace=dev-inventory --context=aws-dev --request-timeout=15

[DEBUG][2020-01-21 17:48:00 +0000]	Running command (attempt 1): kubectl create -f /tmp/Deployment-inventory20200121-88-2op2z.yml --dry-run --output=name --namespace=dev-inventory --context=aws-dev --request-timeout=15

[DEBUG][2020-01-21 17:48:00 +0000]	Running command (attempt 1): kubectl create -f /tmp/Service-influxdb20200121-88-g1u14l.yml --dry-run --output=name --namespace=dev-inventory --context=aws-dev --request-timeout=15

[DEBUG][2020-01-21 17:48:00 +0000]	Running command (attempt 1): kubectl create -f /tmp/ConfigMap-dev-telegraf20200121-88-1n8ptna.yml --dry-run --output=name --namespace=dev-inventory --context=aws-dev --request-timeout=15

[DEBUG][2020-01-21 17:48:02 +0000]	Kubectl out: 

[DEBUG][2020-01-21 17:48:02 +0000]	Kubectl err: 

[DEBUG][2020-01-21 17:48:03 +0000]	Kubectl out: configmap/proxysql 

[DEBUG][2020-01-21 17:48:03 +0000]	Kubectl out: configmap/dev-telegraf 

[DEBUG][2020-01-21 17:48:03 +0000]	Kubectl out: configmap/inventory 

[DEBUG][2020-01-21 17:48:03 +0000]	Kubectl out: deployment.apps/inventory 

[DEBUG][2020-01-21 17:48:03 +0000]	Kubectl out: service/inventory 

[DEBUG][2020-01-21 17:48:03 +0000]	Kubectl out: service/influxdb ```



I think the processes we're spinning off are getting killed, leaving us without anything from stdout/err. Would like to see status code so I can tell if someone is 🔪 our processes.